### PR TITLE
defunkt/hub 用の設定の流用

### DIFF
--- a/lib/git_issue.rb
+++ b/lib/git_issue.rb
@@ -41,6 +41,11 @@ module GitIssue
       res.strip
     end
 
+    def global_configured_value(name)
+      res = `git config --global #{name}`
+      res.strip
+    end
+
     def its_klass_of(its_type)
       case its_type
         when /redmine/i then GitIssue::Redmine
@@ -50,7 +55,7 @@ module GitIssue
       end
     end
 
-    module_function :configured_value, :configure_error, :its_klass_of
+    module_function :configured_value, :global_configured_value, :configure_error, :its_klass_of
   end
 
   def self.main(argv)
@@ -59,6 +64,15 @@ module GitIssue
     begin
       its_type = Helper.configured_value('type')
       apikey   = Helper.configured_value('apikey')
+
+      # Use global config for hub
+      if its_type.blank?
+        github_user = Helper.global_configured_value('github.user')
+        unless github_user.blank?
+          its_type = 'github'
+          apikey   = Helper.global_configured_value('github.token')
+        end
+      end
 
       Helper.configure_error('type (redmine | github)', "git config issue.type redmine") if its_type.blank?
       Helper.configure_error('apikey', "git config issue.apikey some_api_key")           if apikey.blank?

--- a/lib/git_issue/github.rb
+++ b/lib/git_issue/github.rb
@@ -6,12 +6,14 @@ class GitIssue::Github < GitIssue::Base
     super(args, options)
 
     @apikey = options[:apikey] || configured_value('apikey')
+    @apikey = global_configured_value('github.token') if @apikey.blank?
     configure_error('apikey', "git config issue.apikey some_api_key") if @apikey.blank?
 
     @repo = options[:repo] || configured_value('repo')
     configure_error('repo', "git config issue.repo git-issue")  if @repo.blank?
 
     @user = options[:user] || configured_value('user')
+    @user = global_configured_value('github.user') if @user.blank?
     configure_error('user', "git config issue.user yuroyoro")  if @user.blank?
 
   end


### PR DESCRIPTION
既にhubを利用していて、issue.typeにgithubを指定する場合、issue.userや
issue.apikeyが、github.userやgithub.tokenと被るため、そのまま設定を流用
できるようにしてみたのですが、いかがでしょうか。
