### PR TITLE
apikeyの取得を各type用クラスに任せる

### DIFF
--- a/lib/git_issue.rb
+++ b/lib/git_issue.rb
@@ -64,19 +64,16 @@ module GitIssue
 
     begin
       its_type = Helper.configured_value('type')
-      apikey   = Helper.configured_value('apikey')
 
       # Use global config for hub
       if its_type.blank?
         github_user = Helper.global_configured_value('github.user')
         unless github_user.blank?
           its_type = 'github'
-          apikey   = Helper.global_configured_value('github.token')
         end
       end
 
       Helper.configure_error('type (redmine | github)', "git config issue.type redmine") if its_type.blank?
-      Helper.configure_error('apikey', "git config issue.apikey some_api_key")           if apikey.blank?
 
       its_klass = Helper.its_klass_of(its_type)
       status = its_klass.new(ARGV).execute || true


### PR DESCRIPTION
apikey取得は、redmine.rb、github.rb それぞれでも行っているので、
git_issue.rbでは不要かな、と思いました
