### PR TITLE
issueの追加、変更、コメント時に、エディタを利用するようにしてみました

### DIFF
--- a/lib/git_issue/base.rb
+++ b/lib/git_issue/base.rb
@@ -266,5 +266,6 @@ class GitIssue::Base
     @syserr.puts msg
   end
 
+
 end
 


### PR DESCRIPTION
これも hub inspired なんですが、issue を追加、変更、コメントする時に、
エディタを開いて入力できるようにしてみました。

追加、変更の場合は、一行目がタイトル、二行目はブランクにして、三行目が
ボディ。コメントの場合はボディのみ。としています。

github.rb しか修正していませんが、エディタ周りのコードは、GitIssue::Helper
の中に入れてありますので、おそらく redmine.rb からも使えると思います。

なんかあまりキレイなコードじゃないので、添削していただけると幸いです。
