### PR TITLE
Set Net::HTTP#use_ssl when using https for redmine.

### DIFF
--- a/lib/git_issue/redmine.rb
+++ b/lib/git_issue/redmine.rb
@@ -204,6 +204,10 @@ class Redmine < GitIssue::Base
     end
 
     http = Net::HTTP.new(uri.host, uri.port)
+    if uri.scheme == 'https'
+      http.use_ssl = true
+      http.verify_mode = OpenSSL::SSL::VERIFY_NONE
+    end
     http.set_debug_output $stderr if @debug && http.respond_to?(:set_debug_output)
     http.start{|http|
 


### PR DESCRIPTION
Redmine の URL が https であった場合に use_ssl をセットするようにしました。

verify_mode は --sslnoverify を見るべきなのかなとも思ったのですが、とりあえず何もしていません。

マージして頂けるとうれしいです。
