### PR TITLE
no such file to load -- term/ansicolor (LoadError) 対策

### DIFF
--- a/git-issue.gemspec
+++ b/git-issue.gemspec
@@ -20,5 +20,6 @@ Gem::Specification.new do |s|
   # dependencies
   s.add_dependency 'activesupport'
   s.add_dependency 'pit'
+  s.add_dependency 'term-ansicolor'
 end
 


### PR DESCRIPTION
gem install git-issueしたときにterm-ansicolorが追加されなかったのでgemspecに追記しました
