### PR TITLE
View issue in browser

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,6 +59,7 @@ set user and password of github(for authentication)
 
     Commnads:
       show     s show given issue summary. if given no id,  geuss id from current branch name.
+      view     v view issue in browser. if given no id,  geuss id from current branch name.
       list     l listing issues.
       mine     m display issues that assigned to you.
       commit   c commit with filling issue subject to messsage.if given no id, geuss id from current branch name.
@@ -104,6 +105,7 @@ set user and password of github(for authentication)
 
     Commnads:
       show     s show given issue summary. if given no id,  geuss id from current branch name.
+      view     v view issue in browser. if given no id,  geuss id from current branch name.
       list     l listing issues.
       mine     m display issues that assigned to you.
       commit   c commit with filling issue subject to messsage.if given no id, geuss id from current branch name.

--- a/lib/git_issue/base.rb
+++ b/lib/git_issue/base.rb
@@ -107,6 +107,7 @@ class GitIssue::Base
   def commands
     [
     GitIssue::Command.new(:show,   :s, 'show given issue summary. if given no id,  geuss id from current branch name.'),
+    GitIssue::Command.new(:view,   :v, 'view issue in browser. if given no id,  geuss id from current branch name.'),
     GitIssue::Command.new(:list,   :l, 'listing issues.'),
     GitIssue::Command.new(:mine,   :m, 'display issues that assigned to you.'),
     GitIssue::Command.new(:commit, :c, 'commit with filling issue subject to messsage.if given no id, geuss id from current branch name.'),

--- a/lib/git_issue/github.rb
+++ b/lib/git_issue/github.rb
@@ -55,6 +55,13 @@ class GitIssue::Github < GitIssue::Base
     end
   end
 
+  def view(options = {})
+    ticket = options[:ticket_id]
+    raise 'ticket_id is required.' unless ticket
+    url = URI.join('https://github.com/', [@user, @repo, 'issues', ticket].join("/"))
+    system "git web--browse #{url}"
+  end
+
   def list(options = {})
     state = options[:state] || "open"
 

--- a/lib/git_issue/redmine.rb
+++ b/lib/git_issue/redmine.rb
@@ -37,6 +37,13 @@ class Redmine < GitIssue::Base
     end
   end
 
+  def view(options = {})
+    ticket = options[:ticket_id]
+    raise 'ticket_id is required.' unless ticket
+    url = to_url('issues', ticket)
+    system "git web--browse #{url}"
+  end
+
   def list(options = {})
     url = to_url('issues')
     max_count = options[:max_count].to_s if options[:max_count]


### PR DESCRIPTION
チケットをブラウザで開くサブコマンドです。

```
usage:
    git-issue view [ticket]
```
