### PR TITLE
Fix a bug which creates NUL file when in Cygwin

### DIFF
--- a/lib/git_issue.rb
+++ b/lib/git_issue.rb
@@ -22,7 +22,7 @@ require 'active_support/all'
 require 'shellwords'
 require 'term/ansicolor'
 
-Term::ANSIColor::coloring = STDOUT.isatty && RUBY_PLATFORM.downcase !~ /mswin(?!ce)|mingw|bccwin|cygwin/
+Term::ANSIColor::coloring = STDOUT.isatty && RUBY_PLATFORM.downcase !~ /mswin(?!ce)|mingw|bccwin/
 
 
 module GitIssue

--- a/lib/git_issue.rb
+++ b/lib/git_issue.rb
@@ -76,7 +76,7 @@ module GitIssue
     end
 
     def work_dir
-      dir = RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin|cygwin/ ?
+      dir = RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin/ ?
         `git rev-parse -q --git-dir 2> NUL`.strip :
         `git rev-parse -q --git-dir 2> /dev/null`.strip
       dir.empty? ? Dir.tmpdir : dir

--- a/lib/git_issue/base.rb
+++ b/lib/git_issue/base.rb
@@ -179,7 +179,7 @@ class GitIssue::Base
   end
 
   def current_branch
-    RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin|cygwin/ ?
+    RUBY_PLATFORM.downcase =~ /mswin(?!ce)|mingw|bccwin/ ?
       %x(git branch -l 2> NUL | grep "*" | cut -d " " -f 2).strip :
       %x(git branch -l 2> /dev/null | grep "*" | cut -d " " -f 2).strip
   end


### PR DESCRIPTION
Cygwinで使用すると謎の`NUL`ファイルが生成されてしまう（Cygwinからでないと削除できない）のでそれに対するfixです。

- 不要なエラー出力をCygwinでも`/dev/null`にリダイレクトさせる
- ついでにCygwinでも色付け出力させる

宜しくお願いいたします。